### PR TITLE
feat: add landing hero and stats sections

### DIFF
--- a/app/LuxMediHero.tsx
+++ b/app/LuxMediHero.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import React, { useState } from "react";
+
+// Navigation bar for the landing page
+const Navbar = () => (
+  <nav className="w-full bg-black text-white flex items-center justify-between px-6 md:px-8 py-4">
+    <div className="flex items-center space-x-4">
+      <span className="font-bold text-lg tracking-widest">LUXMEDI</span>
+      <ul className="hidden md:flex space-x-6 text-sm font-medium">
+        <li><a href="#" className="hover:underline">ONLINE PRESCRIPTION</a></li>
+        <li><a href="#" className="hover:underline">MEDICAL CERTIFICATE</a></li>
+        <li><a href="#" className="hover:underline">REFERRAL FOR TESTS</a></li>
+        <li><a href="#" className="hover:underline">OTHER SERVICES</a></li>
+        <li><a href="#" className="hover:underline">HELP</a></li>
+      </ul>
+    </div>
+    <div className="flex items-center space-x-2">
+      <button className="border border-gray-700 rounded px-3 py-1 flex items-center gap-2 text-sm">
+        <span role="img" aria-label="flag">🇬🇧</span> ENG ▼
+      </button>
+      <button className="bg-teal-400 hover:bg-teal-500 text-black font-semibold rounded-full px-5 py-2 ml-3 transition">
+        Book Now
+      </button>
+      <button className="border border-white rounded-full px-4 py-2 ml-2 text-white">
+        Contact Us →
+      </button>
+    </div>
+  </nav>
+);
+
+interface ConsultationSelectorProps {
+  value: string;
+  setValue: (value: string) => void;
+}
+
+// Selector for consultation types
+const ConsultationSelector = ({ value, setValue }: ConsultationSelectorProps) => {
+  const options = ["General", "Psychiatry", "Cardiology", "Gynecology", "Orthopedics"];
+  return (
+    <div className="bg-white rounded-xl shadow-xl p-6 flex flex-col items-center w-full max-w-2xl mx-auto mt-8">
+      <h3 className="font-semibold mb-4 text-lg text-center">Book Your Consultation</h3>
+      <div className="flex gap-2 flex-wrap justify-center">
+        {options.map((opt) => (
+          <button
+            key={opt}
+            className={`px-5 py-2 rounded-full font-medium transition ${
+              value === opt
+                ? "bg-black text-white"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+            }`}
+            onClick={() => setValue(opt)}
+          >
+            {opt}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+// Hero section of the landing page
+const HeroSection = () => {
+  const [selected, setSelected] = useState("Cardiology");
+
+  return (
+    <section className="relative min-h-[80vh] flex flex-col items-center justify-center bg-gray-100 overflow-hidden">
+      <div className="w-full bg-teal-100 text-teal-900 text-center text-xs py-2 px-4">
+        First consultation with up to 30% off — choose chat, call, or video. Use code: LUXMEDI
+      </div>
+      <div className="absolute inset-0 w-full h-full bg-gradient-to-b from-white/90 to-gray-100 z-0" />
+      <div className="relative z-10 flex flex-col items-center px-4 pt-20 pb-10">
+        <h1 className="text-4xl md:text-5xl font-extrabold text-center mb-4 leading-tight">
+          Your Health Matters—Because <br className="hidden md:block" />
+          You Deserve to Feel Okay
+        </h1>
+        <p className="text-lg md:text-xl text-center max-w-2xl mb-8 text-gray-700">
+          It strikes the right balance—building trust, offering genuine support, and speaking to people in a way that feels real, human, and easy to connect with.
+        </p>
+        <ConsultationSelector value={selected} setValue={setSelected} />
+        <div className="flex justify-center mt-6">
+          <span className="bg-gray-900 text-white font-semibold rounded-full px-8 py-3 text-lg">
+            consult a medical professional <span className="font-bold">From 69BRL</span>
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+// Combined component for the landing page hero with navigation
+const LuxMediHero = () => (
+  <div className="w-full min-h-screen flex flex-col bg-gray-100">
+    <Navbar />
+    <HeroSection />
+  </div>
+);
+
+export default LuxMediHero;
+

--- a/app/StatsAndServicesSection.tsx
+++ b/app/StatsAndServicesSection.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import Image from "next/image";
+
+// Kafelek statystyki górnej
+const StatCard = ({ icon, value, label, bg }: { icon: React.ReactNode; value: string; label: string; bg: string }) => (
+  <div className={`flex flex-col items-center justify-center rounded-xl px-6 py-4 min-w-[170px] ${bg}`}>
+    <div className="text-3xl mb-1">{icon}</div>
+    <div className="font-bold text-2xl">{value}</div>
+    <div className="text-xs mt-1 text-gray-700 text-center">{label}</div>
+  </div>
+);
+
+// Kafelek usługi
+const ServiceCard = ({ icon, title, desc, link }: { icon: React.ReactNode; title: string; desc: string; link?: string }) => (
+  <div className="bg-white rounded-2xl shadow-md p-6 flex flex-col gap-2 min-h-[150px]">
+    <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center mb-1">
+      {icon}
+    </div>
+    <div className="font-semibold">{title}</div>
+    <div className="text-sm text-gray-600 flex-1">{desc}</div>
+    {link && (
+      <a href="#" className="text-blue-500 text-sm mt-2 underline">{link}</a>
+    )}
+  </div>
+);
+
+// Główny komponent sekcji
+const StatsAndServicesSection = () => (
+  <section className="w-full max-w-6xl mx-auto px-4 py-12">
+    {/* Statystyki na górze */}
+    <div className="flex flex-wrap justify-between gap-4 mb-10">
+      <StatCard
+        icon={<span>✅</span>}
+        value="12,480"
+        label="Appointments Completed"
+        bg="bg-green-100"
+      />
+      <StatCard
+        icon={<span>💬</span>}
+        value="6,750"
+        label="Chats That Made a Difference"
+        bg="bg-blue-100"
+      />
+      <StatCard
+        icon={<span>❤️</span>}
+        value="4,320"
+        label="Happy Patients"
+        bg="bg-red-100"
+      />
+      <StatCard
+        icon={<span role="img" aria-label="doctor">🧑‍⚕️</span>}
+        value="20+"
+        label="Certified Doctors"
+        bg="bg-pink-100"
+      />
+    </div>
+
+    {/* Sekcja z tytułem i gridem */}
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-10 items-start">
+      {/* Lewa kolumna */}
+      <div>
+        <h2 className="text-3xl md:text-4xl font-extrabold mb-4 leading-tight">
+          Symptoms to Solutions<br />—We’ve Got You
+        </h2>
+        <p className="text-gray-700 text-base md:text-lg mb-8 max-w-lg">
+          It strikes the right balance—building trust, offering genuine support, and speaking to people in a way that feels real, human, and easy to connect with. Whether you need a prescription, medical certificate, we’re here to guide you from your symptoms to the right care.
+        </p>
+        {/* Duże zdjęcie */}
+        <div className="relative rounded-2xl overflow-hidden shadow-md w-full max-w-md aspect-square">
+          <Image
+            src="https://images.unsplash.com/photo-1511367461989-f85a21fda167?auto=format&fit=facearea&w=600&q=80"
+            alt="Happy patient"
+            fill
+            className="object-cover"
+          />
+        </div>
+      </div>
+      {/* Prawa kolumna */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+        <ServiceCard
+          icon={<svg width="24" height="24" fill="none" className="text-blue-600"><rect width="24" height="24" rx="5" fill="currentColor" /></svg>}
+          title="Prescriptions by Message"
+          desc="Receive your electronic prescription by SMS or email—valid at any pharmacy."
+          link="Read more"
+        />
+        <ServiceCard
+          icon={<svg width="24" height="24" fill="none" className="text-blue-600"><circle cx="12" cy="12" r="10" fill="currentColor" /></svg>}
+          title="Preventive Health Guidance"
+          desc="Get referrals for essential exams and take charge of your health. We make it easy to stay on top of your wellbeing"
+        />
+        <ServiceCard
+          icon={<svg width="24" height="24" fill="none" className="text-blue-600"><rect x="4" y="4" width="16" height="16" rx="4" fill="currentColor" /></svg>}
+          title="Consultations by chat"
+          desc="Talk to a doctor via phone, chat, or video—fast and discreet. With online prescription and a medical certificate"
+        />
+        <ServiceCard
+          icon={<svg width="24" height="24" fill="none" className="text-blue-600"><circle cx="12" cy="12" r="10" fill="currentColor" /></svg>}
+          title="Sick Leave Made Simple"
+          desc="Get a medical certificate for yourself or your child when needed."
+          link="Read more"
+        />
+      </div>
+    </div>
+  </section>
+);
+
+export default StatsAndServicesSection;
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,11 @@
-import {getTranslations} from 'next-intl/server';
-import {auth} from '@/auth';
+import LuxMediHero from "./LuxMediHero";
+import StatsAndServicesSection from "./StatsAndServicesSection";
 
-export default async function Home() {
-  const t = await getTranslations('HomePage');
-  console.log('render',(await auth()))
+export default function Home() {
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col items-center py-24 px-8">
-      <h1 className="text-[#333333] text-5xl">{t('title')}</h1>
-      <h2 className="text-[#333333] text-5xl">{String((await auth())?.user?.role)}</h2>
-      
-    </div>
+    <>
+      <LuxMediHero />
+      <StatsAndServicesSection />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add LuxMediHero component with navigation and hero section
- render LuxMediHero on the home page
- introduce StatsAndServicesSection with key stats and service cards
- render StatsAndServicesSection below the hero

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e29ff45c4832c9437631eb98a3505